### PR TITLE
fix compilation errors with gcc-4.9

### DIFF
--- a/jit.c
+++ b/jit.c
@@ -708,8 +708,8 @@ static int is_end_of_trace(lir_builder_t *builder, jit_event_t *e)
     //    return 1;
     //}
     if (is_irregular_event(e)) {
+        jit_snapshot_t *snapshot;
 	e->reason = TRACE_ERROR_THROW;
-	jit_snapshot_t *snapshot;
 	snapshot = lir_builder_take_snapshot(builder, REG_PC);
 	if (JIT_DEBUG_VERBOSE) {
 	    fprintf(stderr, "exit trace : : throw error\n");

--- a/jit_args.h
+++ b/jit_args.h
@@ -600,7 +600,7 @@ setup_parameters_complex(lir_builder_t *builder, rb_thread_t *const th, const rb
 
     if (iseq->param.flags.has_kw) {
 	if (args->kw_argv != NULL) {
-	    asm volatile("int3");
+	    __asm__ volatile("int3");
 	    lir_arg.passed_entry = args->kw_entry;
 	    if (args_setup_kw_parameters(builder, &lir_arg, args->ci->kw_arg->keyword_len,
 	                                 args->ci->kw_arg->keywords, iseq) == 0) {
@@ -609,7 +609,7 @@ setup_parameters_complex(lir_builder_t *builder, rb_thread_t *const th, const rb
 	} else if (!NIL_P(keyword_hash)) {
 	    int kw_len = rb_long2int(RHASH_SIZE(keyword_hash));
 	    struct fill_values_arg arg;
-	    asm volatile("int3");
+	    __asm__ volatile("int3");
 	    /* copy kw_argv */
 	    arg.keys = args->kw_argv = ALLOCA_N(VALUE, kw_len * 2);
 	    arg.vals = arg.keys + kw_len;
@@ -725,7 +725,7 @@ vm_caller_setup_arg_kw(lir_builder_t *builder, rb_control_frame_t *cfp, rb_call_
     int i;
     lir_t entry[kw_len * 2];
 
-    asm volatile("int3");
+    __asm__ volatile("int3");
     for (i = kw_len - 1; i > 0; i--) {
 	lir_t key = emit_load_const(builder, ID2SYM(passed_keywords[i]));
 	entry[i * 2] = key;

--- a/jit_record.h
+++ b/jit_record.h
@@ -1147,12 +1147,13 @@ static void record_opt_case_dispatch(lir_builder_t *builder, jit_event_t *e)
 
 static void record_opt_not(lir_builder_t *builder, jit_event_t *e)
 {
+    jit_snapshot_t *snapshot;
     CALL_INFO ci = (CALL_INFO)GET_OPERAND(1);
     VALUE recv = TOPN(0);
     extern VALUE rb_obj_not(VALUE obj);
     vm_search_method(ci, recv);
 
-    jit_snapshot_t *snapshot = take_snapshot(builder, REG_PC);
+    snapshot = take_snapshot(builder, REG_PC);
     if (check_cfunc(ci->me, rb_obj_not)) {
 	lir_t Rrecv = _TOPN(0);
 	EmitIR(GuardMethodCache, REG_PC, Rrecv, ci);


### PR DESCRIPTION
Several warnings are regarded as errors in recent gcc, so fix them.
Tested with gcc version 4.9.3 and 5.1.0
